### PR TITLE
Update GitHub workflows to supported artifact/cache actions.

### DIFF
--- a/.github/workflows/analyze_pr.yml
+++ b/.github/workflows/analyze_pr.yml
@@ -28,7 +28,7 @@ jobs:
           java-version: '17'
 
       - name: Cache Gradle and Wrapper
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches

--- a/.github/workflows/main_build_release.yml
+++ b/.github/workflows/main_build_release.yml
@@ -30,7 +30,7 @@ jobs:
           java-version: '17'
 
       - name: Cache Gradle and Wrapper
-        uses: actions/cache@v3.3.2
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -63,7 +63,7 @@ jobs:
         run: ./gradlew app:bundleRelease
 
       - name: Upload Release Build to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: release-artifacts
           path: |


### PR DESCRIPTION
Migrate deprecated actions/cache v3.3.2 to v4 in CI workflows and upgrade upload-artifact to v4 to prevent upcoming GitHub Actions deprecation-related pipeline failures.