### PR TITLE
Update build tooling to Kotlin 2.0/AGP 8.13 and align Compose plugin setup.

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="tabSettings">
+      <map>
+        <entry key="Firebase Crashlytics">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="dev.baharudin.tmdb_android" />
+                  <option name="mobileSdkAppId" value="1:697027570570:android:1d12b6a45f84f9ba507673" />
+                  <option name="projectId" value="portfolio-tmdb" />
+                  <option name="projectNumber" value="697027570570" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="THIRTY_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="17" />
+    <bytecodeTargetLevel target="21" />
   </component>
 </project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -15,6 +15,7 @@
             </builds>
           </compositeBuild>
         </compositeConfiguration>
+        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="gradleHome" value="$USER_HOME$/.sdkman/candidates/gradle/current" />
         <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
@@ -26,7 +27,6 @@
             <option value="$PROJECT_DIR$/core" />
           </set>
         </option>
-        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -4,6 +4,7 @@
     <option name="jvmTarget" value="17" />
   </component>
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="1.9.21" />
+    <option name="externalSystemId" value="Gradle" />
+    <option name="version" value="2.0.21" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.PatternConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+        <option value="com.intellij.execution.junit.testDiscovery.JUnitTestDiscoveryConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinJUnitRunConfigurationProducer" />
+        <option value="org.jetbrains.kotlin.idea.junit.KotlinPatternConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "java.configuration.updateBuildConfiguration": "disabled"
+}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ import java.util.Properties
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("com.google.gms.google-services")
     id("kotlin-android")
     id("kotlin-parcelize")
@@ -15,14 +16,14 @@ plugins {
 
 android {
     namespace = "dev.baharudin.tmdb_android"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         applicationId = "dev.baharudin.tmdb_android"
         minSdk = 30
-        targetSdk = 34
-        versionCode = 8
-        versionName = "1.2.4"
+        targetSdk = 36
+        versionCode = 9
+        versionName = "1.2.5"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
@@ -76,9 +77,6 @@ android {
     buildFeatures {
         viewBinding = true
         compose = true
-    }
-    composeOptions {
-        kotlinCompilerExtensionVersion = Versions.COMPOSE_COMPILER
     }
     packaging {
         resources {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,8 @@
 buildscript {
     dependencies {
         classpath("androidx.navigation:navigation-safe-args-gradle-plugin:${Versions.NAVIGATION}")
-        classpath("com.google.gms:google-services:4.4.0")
+        classpath("com.google.gms:google-services:4.4.4")
+        classpath("org.jetbrains.kotlin.plugin.compose:org.jetbrains.kotlin.plugin.compose.gradle.plugin:${Versions.KOTLIN}")
     }
     repositories {
         google()
@@ -11,9 +12,10 @@ buildscript {
 plugins {
     id("com.android.application") version Versions.AGP apply false
     id("org.jetbrains.kotlin.android") version Versions.KOTLIN apply false
+    id("org.jetbrains.kotlin.plugin.compose") version Versions.KOTLIN apply false
     id("com.google.dagger.hilt.android") version Versions.HILT apply false
     id("com.google.devtools.ksp") version Versions.KSP apply false
     id("com.android.library") version Versions.AGP apply false
     id("com.android.dynamic-feature") version Versions.AGP apply false
-    id("com.google.gms.google-services") version "4.4.0" apply false
+    id("com.google.gms.google-services") version "4.4.4" apply false
 }

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -1,7 +1,7 @@
 object Versions {
-    const val AGP = "8.2.1"
-    const val KSP = "1.9.21-1.0.16"
-    const val KOTLIN = "1.9.21"
+    const val AGP = "8.13.2"
+    const val KSP = "2.0.21-1.0.28"
+    const val KOTLIN = "2.0.21"
     const val HILT = "2.48"
     const val ROOM = "2.6.1"
     const val RETROFIT = "2.9.0"
@@ -9,6 +9,5 @@ object Versions {
     const val COROUTINES = "1.7.1"
     const val LIFECYCLE = "2.7.0"
     const val PAGING = "3.2.1"
-    const val NAVIGATION = "2.7.6"
-    const val COMPOSE_COMPILER = "1.5.7"
+    const val NAVIGATION = "2.9.7"
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -3,6 +3,7 @@ import com.android.build.gradle.internal.cxx.configure.gradleLocalProperties
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
     id("kotlin-parcelize")
     id("com.google.dagger.hilt.android")
     id("com.google.devtools.ksp")
@@ -10,7 +11,7 @@ plugins {
 
 android {
     namespace = "dev.baharudin.tmdb_android.core"
-    compileSdk = 34
+    compileSdk = 36
 
     defaultConfig {
         minSdk = 30
@@ -23,7 +24,7 @@ android {
         debug {
             if (!System.getenv("GH_ACTIONS_FLAG").toBoolean()) {
                 val accessToken: String =
-                    gradleLocalProperties(rootDir).getProperty("DEV_ACCESS_TOKEN")
+                    gradleLocalProperties(rootDir, providers).getProperty("DEV_ACCESS_TOKEN")
                 buildConfigField("String", "API_KEY", "\"$accessToken\"")
                 buildConfigField("String", "BASE_URL", "\"https://api.themoviedb.org/\"")
             }
@@ -38,7 +39,7 @@ android {
             val accessToken: String = if (System.getenv("GH_ACTIONS_FLAG").toBoolean()) {
                 System.getenv("GH_ACTIONS_PROD_ACCESS_TOKEN")
             } else {
-                gradleLocalProperties(rootDir).getProperty("PROD_ACCESS_TOKEN")
+                gradleLocalProperties(rootDir, providers).getProperty("PROD_ACCESS_TOKEN")
             }
 
             buildConfigField("String", "API_KEY", "\"$accessToken\"")
@@ -58,10 +59,6 @@ android {
     buildFeatures {
         buildConfig = true
         compose = true
-    }
-
-    composeOptions {
-        kotlinCompilerExtensionVersion = Versions.COMPOSE_COMPILER
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Fri Feb 20 11:36:29 ICT 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
This fixes Gradle script compatibility issues introduced by the toolchain upgrade, including compose compiler plugin application and local properties API updates.

Co-authored-by: Cursor <cursoragent@cursor.com>